### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/measurements/manufacturer_index.py
+++ b/measurements/manufacturer_index.py
@@ -3,7 +3,7 @@
 import os
 import sys
 import re
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir)))
 
 DIR_PATH = os.path.abspath(os.path.join(__file__, os.pardir))

--- a/measurements/name_index.py
+++ b/measurements/name_index.py
@@ -5,7 +5,7 @@ import sys
 from glob import glob
 import pandas as pd
 import re
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir)))
 from measurements.utils import split_path
 
@@ -135,10 +135,10 @@ class NameIndex:
 
         Args:
             name: Name to search by. Ignored if None.
-            threshold: Threshold for matching with FuzzyWuzzy.
+            threshold: Threshold for matching with RapidFuzz.
 
         Returns:
-            List of matching triplets with NameItem, FuzzyWuzzy ratio and FuzzyWuzzy token_set_ratio
+            List of matching triplets with NameItem, RapidFuzz ratio and RapidFuzz token_set_ratio
         """
         matches = []
         for item in self.items:
@@ -154,10 +154,10 @@ class NameIndex:
 
         Args:
             name: Name to search by. Ignored if None.
-            threshold: Threshold for matching with FuzzyWuzzy.
+            threshold: Threshold for matching with RapidFuzz.
 
         Returns:
-            List of matching triplets with NameItem, FuzzyWuzzy ratio and FuzzyWuzzy token_set_ratio
+            List of matching triplets with NameItem, RapidFuzz ratio and RapidFuzz token_set_ratio
         """
         matches = []
         for item in self.items:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ tabulate~=0.8.5
 soundfile~=0.10.2
 beautifulsoup4~=4.8.2
 selenium~=3.141.0
-fuzzywuzzy~=0.18.0
+rapidfuzz~=0.2.1


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.