### PR TITLE
Output Rockbox.cfg 10 band eq file

### DIFF
--- a/autoeq.py
+++ b/autoeq.py
@@ -13,13 +13,14 @@ from frequency_response import FrequencyResponse
 
 
 def batch_processing(input_dir=None, output_dir=None, new_only=False, standardize_input=False, compensation=None,
-                     equalize=False, parametric_eq=False, fixed_band_eq=False, fc=None, q=None, ten_band_eq=False,
-                     max_filters=None, convolution_eq=False, fs=DEFAULT_FS, bit_depth=DEFAULT_BIT_DEPTH,
-                     phase=DEFAULT_PHASE, f_res=DEFAULT_F_RES, bass_boost_gain=DEFAULT_BASS_BOOST_GAIN,
-                     bass_boost_fc=DEFAULT_BASS_BOOST_FC, bass_boost_q=DEFAULT_BASS_BOOST_Q, tilt=None,
-                     sound_signature=None, max_gain=DEFAULT_MAX_GAIN, treble_f_lower=DEFAULT_TREBLE_F_LOWER,
-                     treble_f_upper=DEFAULT_TREBLE_F_UPPER, treble_max_gain=DEFAULT_TREBLE_MAX_GAIN,
-                     treble_gain_k=DEFAULT_TREBLE_GAIN_K, show_plot=False):
+                     equalize=False, parametric_eq=False, fixed_band_eq=False, rockbox=False, fc=None, q=None,
+                     ten_band_eq=False, max_filters=None, convolution_eq=False, fs=DEFAULT_FS,
+                     bit_depth=DEFAULT_BIT_DEPTH, phase=DEFAULT_PHASE, f_res=DEFAULT_F_RES,
+                     bass_boost_gain=DEFAULT_BASS_BOOST_GAIN, bass_boost_fc=DEFAULT_BASS_BOOST_FC,
+                     bass_boost_q=DEFAULT_BASS_BOOST_Q, tilt=None, sound_signature=None, max_gain=DEFAULT_MAX_GAIN,
+                     treble_f_lower=DEFAULT_TREBLE_F_LOWER, treble_f_upper=DEFAULT_TREBLE_F_UPPER,
+                     treble_max_gain=DEFAULT_TREBLE_MAX_GAIN, treble_gain_k=DEFAULT_TREBLE_GAIN_K,
+                     show_plot=False):
     """Parses files in input directory and produces equalization results in output directory."""
     start_time = time()
 
@@ -124,6 +125,13 @@ def batch_processing(input_dir=None, output_dir=None, new_only=False, standardiz
                         output_file_path.replace('.csv', ' FixedBandEQ.txt'), fbeq_filters,
                         preamp=-(fbeq_max_gain + PREAMP_HEADROOM))
 
+                # Write 10 band fixed band eq to Rockbox .cfg file
+                if rockbox and ten_band_eq:
+                    # Write fixed band eq settings to file
+                    fr.write_rockbox_10_band_fixed_eq(
+                        output_file_path.replace('.csv', ' RockboxEQ.cfg'), fbeq_filters,
+                        preamp=-(fbeq_max_gain + PREAMP_HEADROOM))
+
                 # Write impulse response as WAV
                 if convolution_eq:
                     for _fs in fs:
@@ -196,6 +204,9 @@ def cli_args():
                             help='Will produce parametric eq settings if this parameter exists, no value needed.')
     arg_parser.add_argument('--fixed_band_eq', action='store_true',
                             help='Will produce fixed band eq settings if this parameter exists, no value needed.')
+    arg_parser.add_argument('--rockbox', action='store_true',
+                            help='Will produce a Rockbox .cfg file with 10 band eq settings if this parameter exists,'
+                            'no value needed.')
     arg_parser.add_argument('--fc', type=str, help='Comma separated list of center frequencies for fixed band eq.')
     arg_parser.add_argument('--q', type=str,
                             help='Comma separated list of Q values for fixed band eq. If only one '


### PR DESCRIPTION
Here I present a new feature to output Rockbox .cfg files that is modeled on the FixedBandEQ.txt output.  I tried to modify the code as little as possible.

Rockbox `.cfg` filter fields from left to right are Fc Hz, Q, and Gain dB.
All of its numbers are expressed as integers with 1 point of precision: `-2.3` -> `-23`
Rockbox `.cfg`'s `eq precut` field implies a negative value.

I've been using the generated `.cfg` files with my Rockbox'd iPod, and am really happy with the results.  Thank you for creating such a great project!

Below are a generated `FixedBandEQ` and `RockboxEQ` file for comparison.

### FixedBandEQ.txt
```
Preamp: -7.2 dB
Filter 1: ON PK Fc 31 Hz Gain -2.3 dB Q 1.41
Filter 2: ON PK Fc 62 Hz Gain -0.6 dB Q 1.41
Filter 3: ON PK Fc 125 Hz Gain -3.9 dB Q 1.41
Filter 4: ON PK Fc 250 Hz Gain -4.6 dB Q 1.41
Filter 5: ON PK Fc 500 Hz Gain 0.9 dB Q 1.41
Filter 6: ON PK Fc 1000 Hz Gain -0.9 dB Q 1.41
Filter 7: ON PK Fc 2000 Hz Gain 0.9 dB Q 1.41
Filter 8: ON PK Fc 4000 Hz Gain 7.3 dB Q 1.41
Filter 9: ON PK Fc 8000 Hz Gain -2.5 dB Q 1.41
Filter 10: ON PK Fc 16000 Hz Gain 0.5 dB Q 1.41
```

### RockboxEQ.txt
```
eq enabled: on
eq precut: 72
eq low shelf filter: 31, 14, -23
eq peak filter 1: 62, 14, -6
eq peak filter 2: 125, 14, -39
eq peak filter 3: 250, 14, -46
eq peak filter 4: 500, 14, 9
eq peak filter 5: 1000, 14, -9
eq peak filter 6: 2000, 14, 9
eq peak filter 7: 4000, 14, 73
eq peak filter 8: 8000, 14, -25
eq high shelf filter: 16000, 14, 5
```