### PR TITLE
Right-aligned table in generated README.md

### DIFF
--- a/frequency_response.py
+++ b/frequency_response.py
@@ -834,7 +834,7 @@ class FrequencyResponse:
                 filters,
                 headers=['Type', 'Fc', 'Q', 'Gain'],
                 tablefmt='orgtbl'
-            ).replace('+', '|').replace('|-', '|:')
+            ).replace('+', '|').replace('-|', ':|')
 
             max_filters_str = ''
             if type(max_filters) == list and len(max_filters) > 1:
@@ -907,7 +907,7 @@ class FrequencyResponse:
                 filters,
                 headers=['Type', 'Fc', 'Q', 'Gain'],
                 tablefmt='orgtbl'
-            ).replace('+', '|').replace('|-', '|:')
+            ).replace('+', '|').replace('-|', ':|')
 
             s += '''
             ### Fixed Band EQs


### PR DESCRIPTION
Example comparison:

| Type    | Fc      |    Q | Gain    |
|:--------|:--------|:-----|:--------|
| Peaking | 23 Hz   | 0.95 | 5.6 dB  |
| Peaking | 59 Hz   | 2.68 | 2.2 dB  |
| Peaking | 1949 Hz | 1.57 | 4.2 dB  |
| Peaking | 3359 Hz | 2.44 | 1.6 dB  |
| Peaking | 5733 Hz | 3.38 | -7.9 dB |

| Type    | Fc      |    Q | Gain    |
|--------:|--------:|-----:|--------:|
| Peaking | 23 Hz   | 0.95 | 5.6 dB  |
| Peaking | 59 Hz   | 2.68 | 2.2 dB  |
| Peaking | 1949 Hz | 1.57 | 4.2 dB  |
| Peaking | 3359 Hz | 2.44 | 1.6 dB  |
| Peaking | 5733 Hz | 3.38 | -7.9 dB |

I think it's easier to read the different frequency and gain values when aligned like the second table.