### PR TITLE
Fix prune_results.py

### DIFF
--- a/results/prune_results.py
+++ b/results/prune_results.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import os
 import sys
+import os
+sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir)))
+
 import shutil
 from glob import glob
 import argparse
@@ -9,8 +11,6 @@ from measurements.crinacle.crinacle_crawler import CrinacleCrawler
 from measurements.oratory1990.oratory1990_crawler import Oratory1990Crawler
 from measurements.referenceaudioanalyzer.reference_audio_analyzer_crawler import ReferenceAudioAnalyzerCrawler
 from measurements.rtings.rtings_crawler import RtingsCrawler
-
-sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir)))
 from constants import ROOT_DIR
 
 


### PR DESCRIPTION
I've been trying to update some measurements based on new results from oratory1990 and had some trouble in the process due to a problem in the script to prune results.

The import hack had to be moved up to allow the imports of the `measurements` package to work.