### PR TITLE
Add missing tqdm dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ numpy~=1.23.1
 tensorflow~=2.9.1
 tabulate~=0.8.10
 soundfile~=0.10.2
+tqdm~=4.64.0


### PR DESCRIPTION
Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>

Looks like somehow this escaped #493.

This is needed for the new progress bar in `autoeq.py`.