### PR TITLE
crinacle Audio-Technica ATH-R70x (Ears-711) ParametricEQ.txt correction

### DIFF
--- a/results/crinacle/gras_43ag-7_harman_over-ear_2018/Audio-Technica ATH-R70x/Audio-Technica ATH-R70x ParametricEQ.txt
+++ b/results/crinacle/gras_43ag-7_harman_over-ear_2018/Audio-Technica ATH-R70x/Audio-Technica ATH-R70x ParametricEQ.txt
@@ -1,11 +1,11 @@
 Preamp: -6.7 dB
 Filter 1: ON LS Fc 105 Hz Gain 11.2 dB Q 0.70
 Filter 2: ON PK Fc 57 Hz Gain -9.6 dB Q 0.43
-Filter 3: ON PK Fc 9509 Hz Gain 4.3 dB Q 1.35
-Filter 4: ON PK Fc 4828 Hz Gain 4.4 dB Q 4.32
+Filter 3: ON PK Fc 4828 Hz Gain 4.4 dB Q 4.32
+Filter 4: ON PK Fc 9509 Hz Gain 4.3 dB Q 1.35
 Filter 5: ON PK Fc 10000 Hz Gain -0.6 dB Q 1.97
-Filter 6: ON HS Fc 10000 Hz Gain -1.1 dB Q 0.70
+Filter 6: ON PK Fc 241 Hz Gain -0.4 dB Q 2.33
 Filter 7: ON PK Fc 2885 Hz Gain 1.8 dB Q 6.00
 Filter 8: ON PK Fc 3582 Hz Gain -1.4 dB Q 5.36
 Filter 9: ON PK Fc 569 Hz Gain 0.3 dB Q 1.66
-Filter 10: ON PK Fc 241 Hz Gain -0.4 dB Q 2.33
+Filter 10: ON HS Fc 10000 Hz Gain -1.1 dB Q 0.70


### PR DESCRIPTION
crinacle Audio-Technica ATH-R70x (Ears-711) ParametricEQ.txt correction based on the README.md Parametric EQs table.