### PR TITLE
add Ears EQ profile & JSON file output to webapp

### DIFF
--- a/webapp/ui/src/EqAppParametricEq.js
+++ b/webapp/ui/src/EqAppParametricEq.js
@@ -40,10 +40,10 @@ const EqAppParametricEq = (props) => {
   const onDownloadClick = () => {
     downloadAsFile(
       props.fileFormatter
-        ? props.fileFormatter(props.parametricEq?.preamp, props.parametricEq?.filters)
+        ? props.fileFormatter(props.parametricEq?.preamp, props.parametricEq?.filters, props.selectedMeasurement)
         : equalizerApoParametricEqString(props.parametricEq?.preamp, props.parametricEq?.filters),
       'text/plain',
-      `${props.selectedMeasurement} ParametricEq.txt`);
+      `${props.selectedMeasurement} ParametricEq.${props.fileType ?? "txt"}`);
   };
 
   const filterNames = !!props.uiConfig?.filterNames ? props.uiConfig.filterNames : {

--- a/webapp/ui/src/EqTab.js
+++ b/webapp/ui/src/EqTab.js
@@ -46,6 +46,7 @@ const EqTab = (props) => {
             instructions={selectedEqualizer?.instructions}
             preamp={props.preamp}
             fileFormatter={selectedEqualizer?.fileFormatter}
+            fileType={selectedEqualizer?.fileType}
           />
         </Grid>
       )}

--- a/webapp/ui/src/equalizers.js
+++ b/webapp/ui/src/equalizers.js
@@ -54,6 +54,32 @@ export default [
     instructions: 'Download file, add Convolver plugin on plugins tab and click "Import impulse" in "Impulses".'
   },
   {
+    label: 'Ears (Chrome Extension)',
+    type: 'parametric',
+    config: {
+      optimizer: { minF: null, maxF: 10000, maxTime: 0.5, minChangeRate: null, minStd: null },
+      filters: [
+        { type: 'LOW_SHELF', fc: null, minFc: 105, maxFc: 105, gain: null, minGain: null, maxGain: null, q: null, minQ: 0.7, maxQ: 0.7 },
+        ...(Array(9).fill(
+          { type: 'PEAKING', fc: null, minFc: null, maxFc: null, gain: null, minGain: null, maxGain: null, q: null, minQ: null, maxQ: null }
+        )),
+        { type: 'HIGH_SHELF', fc: null, minFc: 10000, maxFc: 10000, gain: null, minGain: null, maxGain: null, q: null, minQ: 0.7, maxQ: 0.7 },
+      ]
+    },
+    uiConfig: { showDownload: true },
+    fileFormatter: (_, filters, name) => {
+      return JSON.stringify({
+        [name]: {
+          frequencies: filters.map(filter => filter.fc),
+          gains: filters.map(filter => filter.gain),
+          qs: filters.map(filter => filter.q)
+        }
+      }, null, 2);
+    },
+    fileType: "json",
+    instructions: 'Download file, open Ears, click "Import Presets", select file and drag Volume bar to match Preamp.'
+  },
+  {
     label: 'eqMac (Advanced Equalizer)',
     type: 'fixedBand',
     config: '10_BAND_GRAPHIC_EQ',


### PR DESCRIPTION
Ears Audio Toolkit is a chrome extension for in-browser parametric EQ; have been using it on a work laptop that I can't install system-level EQ on.

Ears uses 9 peaking filters + shelves and imports presets as JSON; one quirk is that it can't directly import preamp values, so I added a blurb on adjusting that to the instructions block.

![image](https://github.com/jaakkopasanen/AutoEq/assets/78172310/bc0abe54-a10e-4168-b967-2ffd6a1f0bb7)
![image](https://github.com/jaakkopasanen/AutoEq/assets/78172310/aecefad8-4d5a-44c0-b15b-71ef3c600bda)
![image](https://github.com/jaakkopasanen/AutoEq/assets/78172310/9ad996e5-4f2f-4b38-a805-3ba28fd9fd06)

