### PR TITLE
Support SuperEQ (fixes #670)

### DIFF
--- a/autoeq/constants.py
+++ b/autoeq/constants.py
@@ -292,4 +292,19 @@ PEQ_CONFIGS = {
             'max_fc': 10000.0,
         }] * 8
     },
+    'SUPER_EQ': {
+        'optimizer': {'min_std': 0.01},
+        'filter_defaults': {'q': 2.871, 'min_gain': -20.0, 'max_gain': 20.0, 'type': 'PEAKING'},
+        'filters': [{
+            'type': 'LOW_SHELF',
+            'fc': 65.406392,
+            'q': 0.7
+        }] + [
+            {'fc': 77.782 * math.sqrt(2) ** i, 'type': 'PEAKING'} for i in range(16)
+        ] + [{
+            'type': 'HIGH_SHELF',
+            'fc': 16744.036,
+            'q': 0.7
+        }]
+    },
 }

--- a/webapp/ui/src/equalizers.js
+++ b/webapp/ui/src/equalizers.js
@@ -188,4 +188,11 @@ export default [
     type: 'graphic',
     instructions: 'Download the file on your phone and import to Wavelet by selecting AutoEq, clicking the headphone name and then Import button'
   },
+  {
+    label: 'Super EQ (foobar2000, DeaDBeeF)',
+    type: 'fixedBand',
+    config: 'SUPER_EQ',
+    uiConfig: { showFsControl: false },
+    instructions: 'Adjust the sliders in your equalizer app to match the gain values. Set preamp to given value if that option is available in the app.'
+  },
 ];


### PR DESCRIPTION
SuperEQ was originally [a Winamp DSP](https://shibatch.sourceforge.net/download/superequ-0.03.zip); now it's mostly known as a default equaliser of foobar2000 and DeaDBeeF. SuperEQ sources have been copied to various projects, the most readable adaptation, in my opinion is [FFmpeg's](https://github.com/FFmpeg/FFmpeg/blob/master/libavfilter/af_superequalizer.c).

Band limits were taken from [af_superequalizer.c#L56](https://github.com/FFmpeg/FFmpeg/blob/master/libavfilter/af_superequalizer.c#L56). The first and the last bands are actually shelf filters: [af_superequalizer.c#L129](https://github.com/FFmpeg/FFmpeg/blob/master/libavfilter/af_superequalizer.c#L129).

I'm not sure what should be used as `fc` for shelf filters, and asking on StackExchange [didn't quite help](https://dsp.stackexchange.com/questions/88580/central-frequencies-of-band-filters-with-cut-offs-at-0-and-the-sampling-rate). GUI shows the frequency of these bands as 55 Hz and 20 kHz, but these were simply obtained by dividing the next/multiplying the previous central frequency by $\sqrt 2$. To me, `fc` seems more like a cut-off frequency, which is what I've committed, and because of it, the first and the last band frequencies in AutoEq GUI don't match bands displayed in players' GUI.

Desktop foobar2000 has both a convolver and a standard 31-band EQ plugins (though none were recompiled for x64), and both foobar2000 and DeaDBeeF can utilise system-wide equaliser apps. However, foobar2000 on iOS can have neither plugins nor system-wide equalisers, and SuperEQ bundled by default is all there is (at least for free).