### PR TITLE
Voicemeeter BANANA EQ preset support routine (fixes #682) / SuperEQ preset support routine (fixes #679)

### DIFF
--- a/autoeq/__main__.py
+++ b/autoeq/__main__.py
@@ -33,6 +33,8 @@ def cli_args():
                             help='Will run equalization if this parameter exists, no value needed.')
     arg_parser.add_argument('--parametric-eq', action='store_true',
                             help='Will produce parametric eq settings if this parameter exists, no value needed.')
+    arg_parser.add_argument('--voicemeeterpeq', action='store_true',
+                            help='Will produce Voicemeeter eq settings if this parameter exists, no value needed.')
     arg_parser.add_argument('--fixed-band-eq', action='store_true',
                             help='Will produce fixed band eq settings if this parameter exists, no value needed.')
     arg_parser.add_argument('--rockbox', action='store_true',

--- a/autoeq/__main__.py
+++ b/autoeq/__main__.py
@@ -33,6 +33,8 @@ def cli_args():
                             help='Will run equalization if this parameter exists, no value needed.')
     arg_parser.add_argument('--parametric-eq', action='store_true',
                             help='Will produce parametric eq settings if this parameter exists, no value needed.')
+    arg_parser.add_argument('--supereq', action='store_true',
+                                help='Will produce SuperEQ settings if this parameter exists, no value needed.')
     arg_parser.add_argument('--voicemeeterpeq', action='store_true',
                             help='Will produce Voicemeeter eq settings if this parameter exists, no value needed.')
     arg_parser.add_argument('--fixed-band-eq', action='store_true',

--- a/autoeq/batch_processing.py
+++ b/autoeq/batch_processing.py
@@ -17,7 +17,7 @@ from autoeq.frequency_response import FrequencyResponse
 
 
 def batch_processing(input_file=None, input_dir=None, output_dir=None, new_only=False, standardize_input=False,
-                     compensation=None, parametric_eq=False, fixed_band_eq=False, rockbox=False,
+                     compensation=None, parametric_eq=False, voicemeeterpeq=False, fixed_band_eq=False, rockbox=False,
                      ten_band_eq=False, parametric_eq_config=None, fixed_band_eq_config=None, convolution_eq=False,
                      fs=DEFAULT_FS, bit_depth=DEFAULT_BIT_DEPTH, phase=DEFAULT_PHASE, f_res=DEFAULT_F_RES,
                      bass_boost_gain=DEFAULT_BASS_BOOST_GAIN, bass_boost_fc=DEFAULT_BASS_BOOST_FC,
@@ -30,7 +30,7 @@ def batch_processing(input_file=None, input_dir=None, output_dir=None, new_only=
                      treble_f_lower=DEFAULT_TREBLE_F_LOWER, treble_f_upper=DEFAULT_TREBLE_F_UPPER,
                      treble_gain_k=DEFAULT_TREBLE_GAIN_K, preamp=DEFAULT_PREAMP, thread_count=0):
     """Parses files in input directory and produces equalization results in output directory."""
-    if not compensation and (parametric_eq or fixed_band_eq or rockbox or ten_band_eq or convolution_eq):
+    if not compensation and (parametric_eq or voicemeeterpeq or fixed_band_eq or rockbox or ten_band_eq or convolution_eq):
         raise ValueError('Compensation must be specified when equalizing.')
 
     if input_file:
@@ -111,7 +111,7 @@ def batch_processing(input_file=None, input_dir=None, output_dir=None, new_only=
                     treble_boost_fc, treble_boost_gain, treble_boost_q,
                     bit_depth, compensation, convolution_eq, f_res, fixed_band_eq, fs, parametric_eq_config,
                     fixed_band_eq_config, max_gain, max_slope, window_size, treble_window_size,
-                    parametric_eq, phase, rockbox, sound_signature, sound_signature_smoothing_window_size,
+                    parametric_eq, voicemeeterpeq, phase, rockbox, sound_signature, sound_signature_smoothing_window_size,
                     standardize_input, ten_band_eq, tilt, treble_f_lower, treble_f_upper, treble_gain_k, preamp)
             args_list.append(args)
 
@@ -132,7 +132,7 @@ def process_file_wrapper(params):
 
 def process_file(input_file_path, output_file_path, bass_boost_fc, bass_boost_gain, bass_boost_q,
                  treble_boost_fc, treble_boost_gain, treble_boost_q, bit_depth,
-                 compensation, convolution_eq, f_res, fixed_band_eq, fs, parametric_eq_config,
+                 compensation, convolution_eq, f_res, fixed_band_eq, voicemeeterpeq, fs, parametric_eq_config,
                  fixed_band_eq_config, max_gain, max_slope, window_size, treble_window_size, parametric_eq, phase,
                  rockbox, sound_signature, sound_signature_smoothing_window_size, standardize_input, ten_band_eq, tilt,
                  treble_f_lower, treble_f_upper, treble_gain_k, preamp):
@@ -159,7 +159,10 @@ def process_file(input_file_path, output_file_path, bass_boost_fc, bass_boost_ga
         # Ten band eq is a shortcut for setting Fc and Q values to standard 10-band equalizer filters parameters
         fixed_band_eq = True
         fixed_band_eq_config = PEQ_CONFIGS['10_BAND_GRAPHIC_EQ']
-
+    
+    if voicemeeterpeq:
+        	voicemeeterpeq = True
+    
     if rockbox and not ten_band_eq:
         raise ValueError('Rockbox configuration requires ten-band eq')
 
@@ -194,6 +197,13 @@ def process_file(input_file_path, output_file_path, bass_boost_fc, bass_boost_ga
     else:
         parametric_peqs = None
 
+    if voicemeeterpeq:
+        parametric_peqs = fr.optimize_parametric_eq(
+            parametric_eq_config, fs[0], preamp=preamp) if parametric_eq else None
+        fr.write_voicemeeter_peq(output_file_path.replace('.csv', '.xml'), parametric_peqs)
+     else:
+        parametric_peqs = None
+         
     if fixed_band_eq:
         fixed_band_peq = fr.optimize_fixed_band_eq(
             fixed_band_eq_config, fs[0], preamp=preamp)[0] if fixed_band_eq else None

--- a/autoeq/batch_processing.py
+++ b/autoeq/batch_processing.py
@@ -161,7 +161,7 @@ def process_file(input_file_path, output_file_path, bass_boost_fc, bass_boost_ga
         fixed_band_eq_config = PEQ_CONFIGS['10_BAND_GRAPHIC_EQ']
     
     if voicemeeterpeq:
-        	voicemeeterpeq = True
+        voicemeeterpeq = True
     
     if rockbox and not ten_band_eq:
         raise ValueError('Rockbox configuration requires ten-band eq')

--- a/autoeq/batch_processing.py
+++ b/autoeq/batch_processing.py
@@ -17,7 +17,7 @@ from autoeq.frequency_response import FrequencyResponse
 
 
 def batch_processing(input_file=None, input_dir=None, output_dir=None, new_only=False, standardize_input=False,
-                     compensation=None, parametric_eq=False, voicemeeterpeq=False, fixed_band_eq=False, rockbox=False,
+                     compensation=None, parametric_eq=False, supereq=False, voicemeeterpeq=False, fixed_band_eq=False, rockbox=False,
                      ten_band_eq=False, parametric_eq_config=None, fixed_band_eq_config=None, convolution_eq=False,
                      fs=DEFAULT_FS, bit_depth=DEFAULT_BIT_DEPTH, phase=DEFAULT_PHASE, f_res=DEFAULT_F_RES,
                      bass_boost_gain=DEFAULT_BASS_BOOST_GAIN, bass_boost_fc=DEFAULT_BASS_BOOST_FC,
@@ -30,7 +30,7 @@ def batch_processing(input_file=None, input_dir=None, output_dir=None, new_only=
                      treble_f_lower=DEFAULT_TREBLE_F_LOWER, treble_f_upper=DEFAULT_TREBLE_F_UPPER,
                      treble_gain_k=DEFAULT_TREBLE_GAIN_K, preamp=DEFAULT_PREAMP, thread_count=0):
     """Parses files in input directory and produces equalization results in output directory."""
-    if not compensation and (parametric_eq or voicemeeterpeq or fixed_band_eq or rockbox or ten_band_eq or convolution_eq):
+    if not compensation and (parametric_eq or supereq or voicemeeterpeq or fixed_band_eq or rockbox or ten_band_eq or convolution_eq):
         raise ValueError('Compensation must be specified when equalizing.')
 
     if input_file:
@@ -111,7 +111,7 @@ def batch_processing(input_file=None, input_dir=None, output_dir=None, new_only=
                     treble_boost_fc, treble_boost_gain, treble_boost_q,
                     bit_depth, compensation, convolution_eq, f_res, fixed_band_eq, fs, parametric_eq_config,
                     fixed_band_eq_config, max_gain, max_slope, window_size, treble_window_size,
-                    parametric_eq, voicemeeterpeq, phase, rockbox, sound_signature, sound_signature_smoothing_window_size,
+                    parametric_eq, supereq, voicemeeterpeq, phase, rockbox, sound_signature, sound_signature_smoothing_window_size,
                     standardize_input, ten_band_eq, tilt, treble_f_lower, treble_f_upper, treble_gain_k, preamp)
             args_list.append(args)
 
@@ -132,7 +132,7 @@ def process_file_wrapper(params):
 
 def process_file(input_file_path, output_file_path, bass_boost_fc, bass_boost_gain, bass_boost_q,
                  treble_boost_fc, treble_boost_gain, treble_boost_q, bit_depth,
-                 compensation, convolution_eq, f_res, fixed_band_eq, voicemeeterpeq, fs, parametric_eq_config,
+                 compensation, convolution_eq, f_res, fixed_band_eq, supereq, voicemeeterpeq, fs, parametric_eq_config,
                  fixed_band_eq_config, max_gain, max_slope, window_size, treble_window_size, parametric_eq, phase,
                  rockbox, sound_signature, sound_signature_smoothing_window_size, standardize_input, ten_band_eq, tilt,
                  treble_f_lower, treble_f_upper, treble_gain_k, preamp):
@@ -160,9 +160,12 @@ def process_file(input_file_path, output_file_path, bass_boost_fc, bass_boost_ga
         fixed_band_eq = True
         fixed_band_eq_config = PEQ_CONFIGS['10_BAND_GRAPHIC_EQ']
     
+    if supereq:
+        supereq = True
+    
     if voicemeeterpeq:
         voicemeeterpeq = True
-    
+        
     if rockbox and not ten_band_eq:
         raise ValueError('Rockbox configuration requires ten-band eq')
 
@@ -196,7 +199,10 @@ def process_file(input_file_path, output_file_path, bass_boost_fc, bass_boost_ga
         fr.write_eqapo_parametric_eq(output_file_path.replace('.csv', ' ParametricEQ.txt'), parametric_peqs)
     else:
         parametric_peqs = None
-
+    
+    if supereq:
+       fr.write_supereq(output_file_path.replace('.csv', '.feq')) 
+        
     if voicemeeterpeq:
         parametric_peqs = fr.optimize_parametric_eq(
             parametric_eq_config, fs[0], preamp=preamp) if parametric_eq else None

--- a/autoeq/constants.py
+++ b/autoeq/constants.py
@@ -310,7 +310,7 @@ PEQ_CONFIGS = {
         },
         'filters': [{
             'type': 'LOW_SHELF',
-            'fc': 65.0,
+            'fc': 65.406392,
             'q': 0.7
         }, 
             {'type': 'PEAKING'},

--- a/autoeq/constants.py
+++ b/autoeq/constants.py
@@ -292,4 +292,38 @@ PEQ_CONFIGS = {
             'max_fc': 10000.0,
         }] * 8
     },
+    'VOICEMEETER_PEQ': {
+        'optimizer': {
+            'min_f': 20,
+            'max_f': 20000,
+            'max_time': None,
+            'min_change_rate': None,
+            'min_std': 0.008,
+        },
+        'filter_defaults': {
+            'min_fc': 20.0,
+            'max_fc': 10000.0,
+            'min_q': 0.18248,
+            'max_q': 6.0,
+            'min_gain': -20,
+            'max_gain': 20
+        },
+        'filters': [{
+            'type': 'LOW_SHELF',
+            'fc': 65.0,
+            'q': 0.7
+        }, 
+            {'type': 'PEAKING'},
+            {'type': 'PEAKING'},
+            {'type': 'PEAKING'},
+            {'type': 'PEAKING'},
+        {
+            'type': 'HIGH_SHELF',
+            'fc': 16744.036,
+            'min_fc': 15000,
+            'max_fc': 20000,
+            'min_q': 0.4,
+            'max_q': 0.7
+        }] 
+    }
 }

--- a/autoeq/frequency_response.py
+++ b/autoeq/frequency_response.py
@@ -1318,14 +1318,13 @@ class FrequencyResponse:
             if np.size(self.gains) > 0:
                 low = [20, 65, 93, 131, 185, 262, 370, 523, 740, 1047, 1480, 2093, 2960, 4186, 5920, 8372, 11840, 16744];
                 high = [65, 93, 131, 185, 262, 370, 523, 740, 1047, 1480, 2093, 2960, 4186, 5920, 8372, 11840, 16744, 20000];
-                for k in range(0,18):
+                for k in range(0,17):
                     G = self.gains[k]
                     ax.plot([low[k],high[k]], [G, G], linestyle='--', color='black', linewidth=1)
-                    ax.plot([low[k],low[k]],[0, G], linestyle='--', color='black', linewidth=1)
-                    ax.plot([high[k],high[k]],[G, 0], linestyle='--', color='black', linewidth=1)
+                    ax.plot([high[k],high[k]],[G, self.gains[k+1]], linestyle='--', color='black', linewidth=1)
                     
-                ax.plot(20000, G, **self.kwarg_defaults(supereq_plot_kwargs, label='SuperEq', linewidth=1, linestyle='--', color='black'))
-
+                ax.plot([low[k+1],high[k+1]],[self.gains[k+1], self.gains[k+1]], **self.kwarg_defaults(supereq_plot_kwargs, label='SuperEq', linewidth=1, linestyle='--', color='black'))
+                
         ax.set_title(self.name)
         if len(ax.lines) > 0:
             ax.legend(fontsize=8)

--- a/autoeq/frequency_response.py
+++ b/autoeq/frequency_response.py
@@ -282,7 +282,6 @@ class FrequencyResponse:
                         s += f'dblevel=\'{filt.gain:.2f}\' '
                         s += f'freq=\'{filt.fc:.2f}\' '
                         s += f'Q=\'{filt.q:.2f}\' />\n'
-                            #print(s)
                             
             s += f'</VoiceMeeterBUSEQ>\n'
             s += f'</VBAudioVoicemeeterBUSEQConfig>'

--- a/autoeq/frequency_response.py
+++ b/autoeq/frequency_response.py
@@ -18,6 +18,7 @@ from time import time
 from PIL import Image
 import re
 import warnings
+import bisect as bisect
 from autoeq.constants import DEFAULT_F_MIN, DEFAULT_F_MAX, DEFAULT_STEP, DEFAULT_MAX_GAIN, DEFAULT_TREBLE_F_LOWER, \
     DEFAULT_TREBLE_F_UPPER, DEFAULT_TREBLE_GAIN_K, DEFAULT_SMOOTHING_WINDOW_SIZE, \
     DEFAULT_SMOOTHING_ITERATIONS, DEFAULT_TREBLE_SMOOTHING_F_LOWER, DEFAULT_TREBLE_SMOOTHING_F_UPPER, \
@@ -42,6 +43,7 @@ class FrequencyResponse:
                  error_smoothed=None,
                  equalization=None,
                  parametric_eq=None,
+                 supereq=None,
                  voicemeeterpeq=None,
                  fixed_band_eq=None,
                  equalized_raw=None,
@@ -61,6 +63,7 @@ class FrequencyResponse:
         self.error_smoothed = self._init_data(error_smoothed)
         self.equalization = self._init_data(equalization)
         self.parametric_eq = self._init_data(parametric_eq)
+        self.supereq = self._init_data(supereq)
         self.voicemeeterpeq = self._init_data(voicemeeterpeq)
         self.fixed_band_eq = self._init_data(fixed_band_eq)
         self.equalized_raw = self._init_data(equalized_raw)
@@ -78,6 +81,7 @@ class FrequencyResponse:
             error_smoothed=self._init_data(self.error_smoothed),
             equalization=self._init_data(self.equalization),
             parametric_eq=self._init_data(self.parametric_eq),
+            supereq=self._init_data(self.supereq),
             voicemeeterpeq=self._init_data(self.voicemeeterpeq),
             fixed_band_eq=self._init_data(self.fixed_band_eq),
             equalized_raw=self._init_data(self.equalized_raw),
@@ -136,6 +140,7 @@ class FrequencyResponse:
               equalization=True,
               fixed_band_eq=True,
               parametric_eq=True,
+              supereq=True,
               voicemeeterpeq=True,
               equalized_raw=True,
               equalized_smoothed=True,
@@ -153,6 +158,8 @@ class FrequencyResponse:
             self.equalization = self._init_data(None)
         if parametric_eq:
             self.parametric_eq = self._init_data(None)
+        if supereq:
+            self.supereq = self._init_data(None)
         if voicemeeterpeq:
             self.voicemeeterpeq = self._init_data(None)
         if fixed_band_eq:
@@ -734,6 +741,7 @@ class FrequencyResponse:
             error_smoothed=True,
             equalization=True,
             parametric_eq=True,
+            supereq=True,
             voicemeeterpeq=True,
             fixed_band_eq=True,
             equalized_raw=True,
@@ -865,6 +873,7 @@ class FrequencyResponse:
             error_smoothed=False,
             equalization=True,
             parametric_eq=True,
+            supereq=True,
             voicemeeterpeq=True,
             fixed_band_eq=True,
             equalized_raw=True,

--- a/webapp/ui/src/equalizers.js
+++ b/webapp/ui/src/equalizers.js
@@ -188,4 +188,11 @@ export default [
     type: 'graphic',
     instructions: 'Download the file on your phone and import to Wavelet by selecting AutoEq, clicking the headphone name and then Import button'
   },
+  {
+    label: 'Voicemeeter BANANA EQ',
+    type: 'parametric',
+    config: 'VOICEMEETER_PEQ',
+    uiConfig: { showFsControl: true },
+    instructions: 'Import generated .xml to Voicemeeter BANANA EQ (right-click EQ window header, ...)'
+  },
 ];


### PR DESCRIPTION
Here's a routine which writes EQ settings for [Voicemeeter Banana](https://vb-audio.com/Voicemeeter/banana.htm) EQ. 

I have tested functionality with command line script:

`python3 -m autoeq --input-file="measurements/oratory1990/data/over-ear/AKG K240 Studio.csv" --output-dir="my_results" --bass-boost 3 --compensation="compensation/harman_over-ear_2018_wo_bass.csv" --voicemeeterpeq --parametric-eq --parametric-eq-config=VOICEMEETER_PEQ`

which produces preset file AKG K240 Studio.xml :

```
<?xml version="1.0" encoding="utf-8"?>
<VBAudioVoicemeeterBUSEQConfig>
<VoiceMeeterBUSEQ>
    <Bus index='1' channel='1' cell='1' EQon='1' EQtype='5' dblevel='6.09' freq='65.00' Q='0.70' />
    <Bus index='1' channel='1' cell='2' EQon='1' EQtype='0' dblevel='-3.37' freq='205.49' Q='0.40' />
    <Bus index='1' channel='1' cell='3' EQon='1' EQtype='0' dblevel='5.36' freq='4220.58' Q='2.96' />
    <Bus index='1' channel='1' cell='4' EQon='1' EQtype='0' dblevel='3.52' freq='71.50' Q='0.93' />
    <Bus index='1' channel='1' cell='5' EQon='1' EQtype='0' dblevel='5.50' freq='1591.25' Q='3.11' />
    <Bus index='1' channel='1' cell='6' EQon='1' EQtype='6' dblevel='3.70' freq='16744.04' Q='0.70' />
    <Bus index='1' channel='2' cell='1' EQon='1' EQtype='5' dblevel='6.09' freq='65.00' Q='0.70' />
    <Bus index='1' channel='2' cell='2' EQon='1' EQtype='0' dblevel='-3.37' freq='205.49' Q='0.40' />
    <Bus index='1' channel='2' cell='3' EQon='1' EQtype='0' dblevel='5.36' freq='4220.58' Q='2.96' />
    <Bus index='1' channel='2' cell='4' EQon='1' EQtype='0' dblevel='3.52' freq='71.50' Q='0.93' />
    <Bus index='1' channel='2' cell='5' EQon='1' EQtype='0' dblevel='5.50' freq='1591.25' Q='3.11' />
    <Bus index='1' channel='2' cell='6' EQon='1' EQtype='6' dblevel='3.70' freq='16744.04' Q='0.70' />
    <Bus index='1' channel='3' cell='1' EQon='1' EQtype='5' dblevel='6.09' freq='65.00' Q='0.70' />
    <Bus index='1' channel='3' cell='2' EQon='1' EQtype='0' dblevel='-3.37' freq='205.49' Q='0.40' />
    <Bus index='1' channel='3' cell='3' EQon='1' EQtype='0' dblevel='5.36' freq='4220.58' Q='2.96' />
    <Bus index='1' channel='3' cell='4' EQon='1' EQtype='0' dblevel='3.52' freq='71.50' Q='0.93' />
    <Bus index='1' channel='3' cell='5' EQon='1' EQtype='0' dblevel='5.50' freq='1591.25' Q='3.11' />
    <Bus index='1' channel='3' cell='6' EQon='1' EQtype='6' dblevel='3.70' freq='16744.04' Q='0.70' />
    <Bus index='1' channel='4' cell='1' EQon='1' EQtype='5' dblevel='6.09' freq='65.00' Q='0.70' />
    <Bus index='1' channel='4' cell='2' EQon='1' EQtype='0' dblevel='-3.37' freq='205.49' Q='0.40' />
    <Bus index='1' channel='4' cell='3' EQon='1' EQtype='0' dblevel='5.36' freq='4220.58' Q='2.96' />
    <Bus index='1' channel='4' cell='4' EQon='1' EQtype='0' dblevel='3.52' freq='71.50' Q='0.93' />
    <Bus index='1' channel='4' cell='5' EQon='1' EQtype='0' dblevel='5.50' freq='1591.25' Q='3.11' />
    <Bus index='1' channel='4' cell='6' EQon='1' EQtype='6' dblevel='3.70' freq='16744.04' Q='0.70' />
    <Bus index='1' channel='5' cell='1' EQon='1' EQtype='5' dblevel='6.09' freq='65.00' Q='0.70' />
    <Bus index='1' channel='5' cell='2' EQon='1' EQtype='0' dblevel='-3.37' freq='205.49' Q='0.40' />
    <Bus index='1' channel='5' cell='3' EQon='1' EQtype='0' dblevel='5.36' freq='4220.58' Q='2.96' />
    <Bus index='1' channel='5' cell='4' EQon='1' EQtype='0' dblevel='3.52' freq='71.50' Q='0.93' />
    <Bus index='1' channel='5' cell='5' EQon='1' EQtype='0' dblevel='5.50' freq='1591.25' Q='3.11' />
    <Bus index='1' channel='5' cell='6' EQon='1' EQtype='6' dblevel='3.70' freq='16744.04' Q='0.70' />
    <Bus index='1' channel='6' cell='1' EQon='1' EQtype='5' dblevel='6.09' freq='65.00' Q='0.70' />
    <Bus index='1' channel='6' cell='2' EQon='1' EQtype='0' dblevel='-3.37' freq='205.49' Q='0.40' />
    <Bus index='1' channel='6' cell='3' EQon='1' EQtype='0' dblevel='5.36' freq='4220.58' Q='2.96' />
    <Bus index='1' channel='6' cell='4' EQon='1' EQtype='0' dblevel='3.52' freq='71.50' Q='0.93' />
    <Bus index='1' channel='6' cell='5' EQon='1' EQtype='0' dblevel='5.50' freq='1591.25' Q='3.11' />
    <Bus index='1' channel='6' cell='6' EQon='1' EQtype='6' dblevel='3.70' freq='16744.04' Q='0.70' />
    <Bus index='1' channel='7' cell='1' EQon='1' EQtype='5' dblevel='6.09' freq='65.00' Q='0.70' />
    <Bus index='1' channel='7' cell='2' EQon='1' EQtype='0' dblevel='-3.37' freq='205.49' Q='0.40' />
    <Bus index='1' channel='7' cell='3' EQon='1' EQtype='0' dblevel='5.36' freq='4220.58' Q='2.96' />
    <Bus index='1' channel='7' cell='4' EQon='1' EQtype='0' dblevel='3.52' freq='71.50' Q='0.93' />
    <Bus index='1' channel='7' cell='5' EQon='1' EQtype='0' dblevel='5.50' freq='1591.25' Q='3.11' />
    <Bus index='1' channel='7' cell='6' EQon='1' EQtype='6' dblevel='3.70' freq='16744.04' Q='0.70' />
    <Bus index='1' channel='8' cell='1' EQon='1' EQtype='5' dblevel='6.09' freq='65.00' Q='0.70' />
    <Bus index='1' channel='8' cell='2' EQon='1' EQtype='0' dblevel='-3.37' freq='205.49' Q='0.40' />
    <Bus index='1' channel='8' cell='3' EQon='1' EQtype='0' dblevel='5.36' freq='4220.58' Q='2.96' />
    <Bus index='1' channel='8' cell='4' EQon='1' EQtype='0' dblevel='3.52' freq='71.50' Q='0.93' />
    <Bus index='1' channel='8' cell='5' EQon='1' EQtype='0' dblevel='5.50' freq='1591.25' Q='3.11' />
    <Bus index='1' channel='8' cell='6' EQon='1' EQtype='6' dblevel='3.70' freq='16744.04' Q='0.70' />
</VoiceMeeterBUSEQ>
</VBAudioVoicemeeterBUSEQConfig>
```
![AKG K240 Studio](https://github.com/jaakkopasanen/AutoEq/assets/141587285/fbb6f17f-e4e3-4908-ba72-d4c9abe81452)

Also tested with a config file voicemeeterpeq.yaml :

```
optimizer:
  min_f: 20
  max_f: 20000 
  max_time: null 
  min_change_rate: null
  min_std: null 
filter_defaults:
  min_fc: 20
  max_fc: 10000
  min_q: 0.18248
  max_q: 6
  min_gain: -20
  max_gain: 20
filters:
  - type: LOW_SHELF
    fc: 65.406392
    q: 0.7
  - type: PEAKING
  - type: PEAKING
  - type: PEAKING
  - type: PEAKING
  - type: HIGH_SHELF
    fc:  16744.036
    min_fc: 15000 
    max_fc: 20000
    min_q: 0.4 
    max_q: 0.7
```

which generates similar .xml file:

`python3 -m autoeq --input-file="measurements/oratory1990/data/over-ear/AKG K240 Studio.csv" --output-dir="my_results" --bass-boost 3 --compensation="compensation/harman_over-ear_2018_wo_bass.csv" --voicemeeterpeq --parametric-eq --parametric-eq-config=voicemeeterpeq.yaml`

Both .xml files loaded properly in Voicemeeter BANANA.

As an alternative, one can use [lxml](https://github.com/lxml/lxml/tree/master) for to write the preset file. Needed changes are then:

install lxml library

in **frequency_response.py**

`from lxml import etree`

and use re-written **write_voicemeeter_peq()** :

```
    def write_voicemeeter_peq(self, file_path, peqs):
        """Writes Voicemeeter BANANA EQ settings to a XML type preset file."""
        file_path = os.path.abspath(file_path)
        f = self.generate_frequencies(f_step=DEFAULT_BIQUAD_OPTIMIZATION_F_STEP)
        compound = PEQ(f, peqs[0].fs, [])
        for peq in peqs:
            for filt in peq.filters:
                compound.add_filter(filt)

        EQType = 0  # equalizer type 0 = peak, 5 = low-shelf, 6=high-self
        
        BUSConfig = etree.Element('VBAudioVoicemeeterBUSEQConfig')
        BUSEQ = etree.SubElement(BUSConfig, 'VoiceMeeterBUSEQ')
        
        for idx in range(1,2):
            for channel in range(1,9):
                for i, filt in enumerate(compound.filters):
                    if 0 < i < 5:
                        EQType = 0
                    elif i == 0:
                        EQType = 5
                    else:
                        EQType = 6
                    
                    etree.SubElement(BUSEQ, 'Bus', index='{:d}'.format(idx), channel='{:d}'.format(channel), cell='{:d}'.format(i+1), \
                                                EQon='1', EQType='{:d}'.format(EQType), dblevel='{:.2f}'.format(filt.gain), freq='{:.2f}'.format(filt.fc), Q='{:.2f}'.format(filt.q))

            tree = etree.ElementTree(BUSConfig)
            tree.write(file_path.replace('.txt', '.xml'), encoding = "UTF-8", xml_declaration=True, pretty_print=True)
```




**=====**

**SuperEQ**, which can be found on few software as like Foobar2k Desktop/Foobar2k Mobile and DeaDBeeF (originally SuperEQ was made for Winamp by N. Shibata),  preset "generator" calculates integer type gains for EQ 18 bands by interpolating gain values directly from **_Equalization_** curve data (green line in plot) at equalizer band center frequencies. Center frequencies are [55, 77, 110, 156, 220, 311, 440, 622, 880, 1200, 1800, 2500, 3500, 5000, 7000, 10000, 14000, 20000] (Hz). The 18 bands covers the following frequency ranges:
```
 # | f (low)  | f (high)
 1 | 0 Hz     | 65 Hz
 2 | 65 Hz    | 93 Hz
 3 | 93 Hz    | 131 Hz
 4 | 131 Hz   | 185 Hz
 5 | 185 Hz   | 262 Hz
 6 | 262 Hz   | 370 Hz
 7 | 370 Hz   | 523 Hz
 8 | 523 Hz   | 740 Hz
 9 | 740 Hz   | 1047 Hz
10 | 1047 Hz  | 1480 Hz
11 | 1480 Hz  | 2093 Hz
12 | 2093 Hz  | 2960 Hz
13 | 2960 Hz  | 4186 Hz
14 | 4186 Hz  | 5920 Hz
15 | 5920 Hz  | 8372 Hz
16 | 8372 Hz  | 11840 Hz
17 | 11840 Hz | 16744 Hz
18 | 16744 Hz | 22000±Hz
```

Test script: 

`python3 -m autoeq --input-file="measurements/oratory1990/data/over-ear/AKG K240 Studio.csv" --output-dir="my_results" --bass-boost 3 --compensation="compensation/harman_over-ear_2018_wo_bass.csv" --supereq`

Plot shows result for AKG K240 Studio:

![AKG K240 Studio](https://github.com/jaakkopasanen/AutoEq/assets/141587285/274d58cf-1ab5-4bd7-877c-0bfa0fa0e56c)

Saved preset file (AKG K240 Studio supereq.feq) format is:
```
6
4
0
-2
-3
-3
-2
-1
-1
1
4
-1
3
4
-1
-1
1
5
```