### PR TITLE
More descriptive Voicemeeter import instructions

### DIFF
--- a/webapp/ui/src/equalizers.js
+++ b/webapp/ui/src/equalizers.js
@@ -251,7 +251,7 @@ export default [
     uiConfig: {
       bw: false, showDownload: true, showFsControl: true,
     },
-    instructions: 'Download the file and import it to Voicemeeter by right clicking the top bar and selecting "Load EQ Settings"',
+    instructions: 'Download the file and import it to Voicemeeter by opening the EQ window for a channel and right clicking the top bar and selecting "Load EQ Settings"',
     fileFormatter: (preamp, filters) => {
       const filterTypes = {
         'LOW_SHELF': '5',


### PR DESCRIPTION
The current instructions are misleading. Right clicking on Voicemeeters window itself doesn't show the "Load EQ Settings" and nor is there an option for it in the dropdown menu. 
"Load EQ Settings" is found on an EQ window, not Voicemeeter itself

![image](https://github.com/jaakkopasanen/AutoEq/assets/18307183/0bf4ca25-7c1d-4f65-be68-f8b5b234b646)
