### PR TITLE
fix: disable pointer-events on waves

### DIFF
--- a/webapp/ui/src/Waves.js
+++ b/webapp/ui/src/Waves.js
@@ -50,7 +50,7 @@ const Waves = (props) => {
       width='100%' viewBox='0 0 100 100'
       preserveAspectRatio='none'
       style={{
-        position: 'fixed', bottom: 0, left: 0, right: 0, height: '300px', maxHeight: '20vh'
+        position: 'fixed', bottom: 0, left: 0, right: 0, height: '300px', maxHeight: '20vh', pointerEvents: 'none'
       }}
     >
       {paths}


### PR DESCRIPTION
Depending on the viewport height, the bottom link to the wiki is not clickable since it's technically behind the waves svg, even though it's still visible (see below). This can be fixed by adding `pointer-events: none;` to the svg style.

![image](https://github.com/jaakkopasanen/AutoEq/assets/78376862/59ba5314-0ea5-46b2-9335-2bec04b21027)

