### PR TITLE
Add Sony Sound Connect app

### DIFF
--- a/autoeq/constants.py
+++ b/autoeq/constants.py
@@ -81,6 +81,11 @@ PEQ_CONFIGS = {
         'filter_defaults': {'q': 4.318473, 'min_gain': -12.0, 'max_gain': 12.0, 'type': 'PEAKING'},
         'filters': [{'fc': 20 * 2 ** (i / 3), 'type': 'PEAKING'} for i in range(31)]
     },
+    'SONY_SOUND_CONNECT_10_BAND': {
+        'optimizer': {'min_std': 0.01},
+        'filter_defaults': {'q': math.sqrt(2), 'min_gain': -6.0, 'max_gain': 6.0, 'type': 'PEAKING'},
+        'filters': [{'fc': 31.25 * 2 ** i} for i in range(10)]
+    },
     '10_PEAKING': {
         'filters': [{'type': 'PEAKING'}] * 10
     },

--- a/webapp/ui/src/equalizers.js
+++ b/webapp/ui/src/equalizers.js
@@ -235,6 +235,13 @@ export default [
     }
   },
   {
+    label: 'Sony Sound Connect',
+    type: 'fixedBand',
+    config: 'SONY_SOUND_CONNECT_10_BAND',
+    uiConfig: { showFsControl: false },
+    instructions: 'Adjust the 10-band equalizer sliders to match the gain values. Sony Sound Connect has limited ±6dB range and no preamp support.'
+  },
+  {
     label: 'Spotify built-in equalizer',
     type: 'fixedBand',
     config: 'SPOTIFY',


### PR DESCRIPTION
Mostly just an idea..

The Sound Connect app finally added at least a 10-band graphic eq, so the AutoEq users can use the 10-band, though the gain range is only ±6, so when I tried to get values for WH-1000XM6, it was out of range.  

I haven't found a good way to enable "max gain range" (or "is preamp available) on the existing graphic eqs, so all I could come up with is this. 
<img width="439" height="604" alt="Screenshot From 2025-08-24 15-24-07" src="https://github.com/user-attachments/assets/49c06f1e-bdd6-43d6-9ec0-7c128e1fd257" />
vs original 10-band:
<img width="439" height="579" alt="Screenshot From 2025-08-24 15-24-02" src="https://github.com/user-attachments/assets/696bc0ed-43b2-4a7b-a71f-e78c7840a248" />
