### PR TITLE
Swap Ears (no longer supported) for Contour EQ

### DIFF
--- a/webapp/ui/src/equalizers.js
+++ b/webapp/ui/src/equalizers.js
@@ -49,32 +49,34 @@ export default [
       </div>
   },
   {
-    label: 'Ears (Chrome Extension)',
+    label: 'Contour EQ (Chrome Extension)',
     type: 'parametric',
-    config: {
-      optimizer: { minF: null, maxF: 10000, maxTime: 0.5, minChangeRate: null, minStd: null },
-      filters: [
-        { type: 'LOW_SHELF', fc: null, minFc: 105, maxFc: 105, gain: null, minGain: null, maxGain: null, q: null, minQ: 0.7, maxQ: 0.7 },
-        ...(Array(9).fill(
-          { type: 'PEAKING', fc: null, minFc: null, maxFc: null, gain: null, minGain: null, maxGain: null, q: null, minQ: null, maxQ: null }
-        )),
-        { type: 'HIGH_SHELF', fc: null, minFc: 10000, maxFc: 10000, gain: null, minGain: null, maxGain: null, q: null, minQ: 0.7, maxQ: 0.7 },
-      ]
-    },
+    config: '8_PEAKING_WITH_SHELVES',
     uiConfig: { showDownload: true, showFsControl: true },
     fileFormatter: (preamp, filters, name) => {
+      const filterTypeMap = {
+        "PEAKING": "peaking",
+        "LOW_SHELF": "lowshelf",
+        "HIGH_SHELF": "highshelf"
+      }
+
       return JSON.stringify({
         [name]: {
-          frequencies: filters.map(filter => filter.fc),
-          gains: filters.map(filter => filter.gain),
-          qs: filters.map(filter => filter.q)
+          bands: filters.map(filter => ({
+            frequency: filter.fc,
+            gain: filter.gain,
+            Q: filter.q,
+            type: filterTypeMap[filter.type]
+          })),
+          preampGain: preamp,
+          presetName: name
         }
       }, null, 2);
     },
     fileName: (name) => {
-      return `${name} Ears.json`
+      return `${name} Contour EQ.json`
     },
-    instructions: 'Download file, open Ears, click "Import Presets", select file and drag Volume bar to match Preamp.'
+    instructions: 'Download the file, open Contour, click "Import" and select the downloaded file. Preset will now appear under the Presets dropdown.'
   },
   {
     label: 'EasyEffects',


### PR DESCRIPTION
The Ears EQ target is no longer relevant/useful since the extension has ceased to function under modern Chromium browsers after the deprecation of Extension Manifest v2 (https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline).

This PR swaps in [Contour EQ](https://chromewebstore.google.com/detail/contour-eq/lclkdnoeflddkmfmadnfcnipdcbmcaah?hl=en-US) as a target. This extension serves as a suitable Ears replacement, offering parametric EQ functionality.