### PR TITLE
Add missing space before platform name in EQ app recommendation

### DIFF
--- a/webapp/ui/src/InfoPage.js
+++ b/webapp/ui/src/InfoPage.js
@@ -81,8 +81,8 @@ const InfoPage = (props) => {
               <Typography variant='h6' sx={{lineHeight: 1.2, mb: '12px'}}>Select equalizer app</Typography>
               {platform !== 'iOS' && (
                 <Typography variant='body2'>
-                  <b style={{color: theme.palette.secondary.light}}>{recommendedApp}</b> is recommended for
-                  <b>{platform}</b>. See <Link
+                  <b style={{color: theme.palette.secondary.light}}>{recommendedApp}</b> is recommended for&nbsp;<b>{platform}</b>.
+                  See <Link
                     href='https://github.com/jaakkopasanen/AutoEq/wiki/Choosing-an-Equalizer-App'
                     target='_blank' rel='noopener'
                     underline='none'


### PR DESCRIPTION
Very minor fix, but that missing space gave me a scare something is wrong again with the fonts on my system.

Before:
<img width="354" height="48" alt="Screenshot 2025-11-02 at 18-26-32 AutoEq" src="https://github.com/user-attachments/assets/cf636bde-1db1-4f2c-be3f-5568020e7840" /> <img width="354" height="48" alt="Screenshot 2025-11-02 at 18-27-14 AutoEq" src="https://github.com/user-attachments/assets/3483316e-cc88-4f7e-803f-e5de72a152f1" />

After:
<img width="354" height="48" alt="Screenshot 2025-11-02 at 18-27-43 AutoEq" src="https://github.com/user-attachments/assets/4489db97-0fb8-42cc-8c84-2f9a959d49b0" /> <img width="354" height="48" alt="Screenshot 2025-11-02 at 18-28-29 AutoEq" src="https://github.com/user-attachments/assets/3217bad3-9c57-4079-82d7-43b0d70b8ed1" />