### PR TITLE
Add Mini EQ equalizer option

### DIFF
--- a/webapp/ui/src/equalizers.js
+++ b/webapp/ui/src/equalizers.js
@@ -121,6 +121,13 @@ export default [
   { label: 'JamesDSP', type: 'convolution' },
   { label: 'RootlessJamesDSP', type: 'convolution' },
   {
+    label: 'Mini EQ',
+    type: 'parametric',
+    config: '8_PEAKING_WITH_SHELVES',
+    uiConfig: { showFsControl: true, showDownload: true },
+    instructions: 'Download the file and import it in Mini EQ with "Import Equalizer APO..."'
+  },
+  {
     label: 'MiniDSP 2x4HD', type: 'parametric', config: 'MINIDSP_2X4HD',
     uiConfig: {
       bw: false, showDownload: false, showFsControl: true,


### PR DESCRIPTION
## Summary
- Add Mini EQ to the AutoEq web app equalizer selector.
- Reuse the existing `8_PEAKING_WITH_SHELVES` parametric export format.
- Add import instructions for Mini EQ's Equalizer APO preset importer.

## Context
Mini EQ is a small GTK/Libadwaita system-wide parametric equalizer for PipeWire desktops. It can import AutoEq's EqualizerAPO ParametricEq text export.

Project: https://github.com/bhack/mini-eq
Flathub: https://flathub.org/apps/io.github.bhack.mini-eq
