### PR TITLE
Add Fidelia to the equalizer apps

### DIFF
--- a/webapp/ui/src/equalizers.js
+++ b/webapp/ui/src/equalizers.js
@@ -112,6 +112,15 @@ export default [
     instructions: 'Download the file to "C:\\Program Files\\EqualizerAPO\\config\\", open "Configuration Editor" app, add a filter "Control > Include" and select the file with 📁.'
   },
   {
+    label: 'Fidelia', type: 'parametric', config: '8_PEAKING_WITH_SHELVES',
+    uiConfig: {
+      bw: false, showDownload: true, showFsControl: true,
+      filterNames: { LOW_SHELF: 'Low-shelf', PEAKING: 'Peak', HIGH_SHELF: 'High-shelf', PREAMP: 'Preamp' },
+      columnNames: { fc: 'Center frequency (Hz)', gain: 'Gain (dB)', q: 'Q' }
+    },
+    instructions: 'Download the file, open it in a text editor and copy its contents. In Fidelia, choose Settings > Equalizer > Import Profile… (iPhone) or Preferences > Equalizer > Import Profile… (Mac) and paste.'
+  },
+  {
     label: 'iTunes built-in equalizer',
     type: 'fixedBand',
     config: '10_BAND_GRAPHIC_EQ',


### PR DESCRIPTION
Fidelia is an audiophile music player for macOS and iOS ([audiofile.engineering](https://audiofile.engineering)) with a built-in parametric EQ. It imports parametric profiles in the EqualizerAPO ParametricEq text format by paste, so this entry uses the default `8_PEAKING_WITH_SHELVES` config and the standard download — no custom formatter needed. Instructions cover both platforms.