### PR TITLE
fix: prevent division by zero in PEQ optimizer callback

### DIFF
--- a/autoeq/peq.py
+++ b/autoeq/peq.py
@@ -1,6 +1,6 @@
 import warnings
 from copy import deepcopy
-from time import time
+from time import perf_counter
 from abc import ABC, abstractmethod
 import numpy as np
 from matplotlib import pyplot as plt, ticker
@@ -420,7 +420,7 @@ class LowShelf(ShelfFilter):
 
 class OptimizationHistory:
     def __init__(self):
-        self.start_time = time()
+        self.start_time = perf_counter()
         self.time = []
         self.loss = []
         self.moving_avg_loss = []
@@ -657,7 +657,7 @@ class PEQ:
     def _callback(self, params):
         """Optimization callback function"""
         n = 8
-        t = time() - self.history.start_time
+        t = perf_counter() - self.history.start_time
         loss = self._optimizer_loss(params, parse=False)
 
         self.history.time.append(t)
@@ -674,7 +674,13 @@ class PEQ:
         if len(self.history.moving_avg_loss) > 1:
             d_loss = loss - self.history.moving_avg_loss[-2]
             d_time = t - self.history.time[-2]
-            change_rate = d_loss / d_time if len(self.history.moving_avg_loss) > n else 0.0
+            # d_time can be 0.0 when two callbacks land within the same clock tick (cheap loss
+            # evaluations can easily outrun the clock's resolution), which would otherwise divide
+            # by zero and poison change_rate with inf/nan. Treat it as "no change measured yet".
+            if len(self.history.moving_avg_loss) > n and d_time > 0.0:
+                change_rate = d_loss / d_time
+            else:
+                change_rate = 0.0
         else:
             change_rate = 0.0
         self.history.change_rate.append(change_rate)

--- a/tests/test_peq.py
+++ b/tests/test_peq.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import patch
+import numpy as np
+from autoeq.peq import PEQ, Peaking, OptimizationHistory
+
+
+class TestPeqCallback(unittest.TestCase):
+    """Regression test for the optimizer callback's change_rate division.
+
+    `PEQ._callback` divides a loss delta by a time delta (`d_time`) measured between two
+    successive optimizer iterations. `d_time` can legitimately be 0.0 when two callbacks land
+    within the same clock tick, e.g. when loss evaluations are cheap relative to the clock's
+    resolution. That must not raise ZeroDivisionError or leak inf/nan into the optimization
+    history, since a nan change rate silently disables the "change too small" stopping
+    criterion for the rest of the run.
+    """
+
+    def setUp(self):
+        self.f = np.geomspace(20, 20000, 50)
+        self.fs = 44100
+        self.target = np.zeros(len(self.f))
+        self.filt = Peaking(
+            self.f, self.fs, fc=1000, q=1.0, gain=3.0,
+            min_fc=20, max_fc=10000, min_q=0.1, max_q=6, min_gain=-12, max_gain=12,
+            optimize_fc=True, optimize_q=True, optimize_gain=True)
+        # Disable every other stopping criterion so only the callback's time handling is exercised.
+        # (min_std=None would fall back to PEQ's non-zero default, so it must be 0 here instead.)
+        self.peq = PEQ(self.f, self.fs, filters=[self.filt], target=self.target, min_std=0.0)
+
+    def test_repeated_timestamp_does_not_divide_by_zero(self):
+        # Absolute perf_counter() readings: the first is consumed as OptimizationHistory's
+        # start_time, the rest as one reading per _callback() call. Indices 8-10 (elapsed
+        # 0.0075s) simulate a clock whose resolution is coarser than the gap between two
+        # callbacks -- exactly the point where change_rate first becomes active, since it
+        # requires more than n=8 samples of history.
+        absolute_timestamps = [
+            0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.0075, 0.0075, 0.0075, 0.008, 0.009,
+        ]
+        dummy_params = np.zeros(3)
+
+        with patch('autoeq.peq.perf_counter', side_effect=absolute_timestamps):
+            self.peq.history = OptimizationHistory()
+            with self.assertRaises(StopIteration):
+                # Exhaust the fake clock rather than guessing exactly how many callbacks fire;
+                # a ZeroDivisionError or RuntimeWarning-as-error would surface before this.
+                with np.errstate(divide='raise', invalid='raise'):
+                    for _ in range(len(absolute_timestamps) + 5):
+                        self.peq._callback(dummy_params)
+
+        self.assertTrue(all(np.isfinite(cr) for cr in self.peq.history.change_rate))
+        self.assertEqual(self.peq.history.time.count(0.0075), 3)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
PEQ._callback() computes the loss change rate as d_loss / d_time, where d_time is the wall-clock gap between two successive optimizer callbacks (measured with time.time()). When loss evaluations are cheap relative to the clock's resolution, two callbacks can land within the same tick, making d_time exactly 0.0 and triggering a "division by zero"/"invalid value" error (or silently producing inf/nan, which then disables the "change too small" stopping criterion for the rest of the run since NaN comparisons are always false).

Switch to time.perf_counter(), which is designed for measuring short intervals and has much finer resolution than time.time() on most platforms, and additionally guard the division so d_time == 0 is treated as "no change measured yet" rather than dividing by zero regardless of clock resolution.

Adds tests/test_peq.py, which reproduces the zero-delta timestamp scenario with a mocked clock and asserts the callback no longer raises or produces non-finite change_rate values.